### PR TITLE
Add coralogix, launchdarkly integrations

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.8.0 (2023-11-19)
+------------------
+
+**Improvements**
+- Add coralogx, launchdarkly integrations.
+
 0.7.0 (2023-11-17)
 ------------------
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -1586,18 +1586,31 @@ def subparser_integrations_opts(subparsers):
 
     ssp = sp.add_parser('aws', help='AWS integration')
     subparser_integrations_aws_opts(ssp)
+
+    ssp = sp.add_parser('coralogix', help='Coralogix integration')
+    subparser_integrations_coralogix_opts(ssp)
+
     ssp = sp.add_parser('datadog', help='Datadog integration')
     subparser_integrations_datadog_opts(ssp)
+
     ssp = sp.add_parser('github', help='GitHub integration')
     subparser_integrations_github_opts(ssp)
+
     ssp = sp.add_parser('gitlab', help='GitLab integration')
     subparser_integrations_gitlab_opts(ssp)
+
+    ssp = sp.add_parser('launchdarkly', help='Launchdarkly integration')
+    subparser_integrations_launchdarkly_opts(ssp)
+
     ssp = sp.add_parser('newrelic', help='Newrelic integration')
     subparser_integrations_newrelic_opts(ssp)
+
     ssp = sp.add_parser('pagerduty', help='Pagerduty integration')
     subparser_integrations_pagerduty_opts(ssp)
+
     ssp = sp.add_parser('prometheus', help='Prometheus integration')
     subparser_integrations_prometheus_opts(ssp)
+
     ssp = sp.add_parser('sonarqube', help='Sonarqube integration')
     subparser_integrations_sonarqube_opts(ssp)
 # Integrations end
@@ -1680,6 +1693,115 @@ def subparser_integrations_aws_delete_all(subparser):
 def integrations_aws_delete_all(args):
     delete("/api/v1/aws/configurations")
 # Integrations-AWS end
+
+# Integrations-coralogix start
+def subparser_integrations_coralogix_opts(subparser):
+    sp = subparser.add_subparsers(help='integrations - coralogix help')
+
+    subparser_integrations_coralogix_add(sp)
+    subparser_integrations_coralogix_add_multiple(sp)
+    subparser_integrations_coralogix_delete(sp)
+    subparser_integrations_coralogix_delete_all(sp)
+    subparser_integrations_coralogix_get(sp)
+    subparser_integrations_coralogix_get_all(sp)
+    subparser_integrations_coralogix_get_default(sp)
+    subparser_integrations_coralogix_update(sp)
+    subparser_integrations_coralogix_validate(sp)
+    subparser_integrations_coralogix_validate_all(sp)
+
+def subparser_integrations_coralogix_add(subparser):
+    sp = subparser.add_parser('add', help='Add a single configuration')
+    add_argument_file(sp, 'File containing JSON-formatted coralogix configuration')
+    sp.set_defaults(func=integrations_coralogix_add)
+
+def integrations_coralogix_add(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    post("/api/v1/coralogix/configuration/", headers, payload=read_file(args))
+
+def subparser_integrations_coralogix_add_multiple(subparser):
+    sp = subparser.add_parser('add-multiple', 
+            help='Add multiple configurations', 
+            formatter_class=argparse.RawTextHelpFormatter, 
+            epilog=textwrap.dedent('''\
+                Format of JSON-formatted configuration file:
+                --------------------------------------------
+                {
+                  "accountId": 0,
+                  "alias": "string",
+                  "isDefault": true,
+                  "personalKey": "string",
+                  "region": "US"
+                }
+                '''))
+    add_argument_file(sp, 'File containing JSON-formatted coralogix configurations')
+    sp.set_defaults(func=integrations_coralogix_add_multiple)
+
+def integrations_coralogix_add_multiple(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    post("/api/v1/coralogix/configurations", headers, payload=read_file(args))
+
+def subparser_integrations_coralogix_delete(subparser):
+    sp = subparser.add_parser('delete', help='Delete a single configuration')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_coralogix_delete)
+
+def integrations_coralogix_delete(args):
+    delete("/api/v1/coralogix/configuration/" + args.alias)
+
+def subparser_integrations_coralogix_delete_all(subparser):
+    sp = subparser.add_parser('delete-all', help='Delete all configurations')
+    sp.set_defaults(func=integrations_coralogix_delete_all)
+
+def integrations_coralogix_delete_all(args):
+    delete("/api/v1/coralogix/configurations")
+
+def subparser_integrations_coralogix_get(subparser):
+    sp = subparser.add_parser('get', help='Get a single configuration')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_coralogix_get)
+
+def integrations_coralogix_get(args):
+    get("/api/v1/coralogix/configuration/" + args.alias)
+
+def subparser_integrations_coralogix_get_all(subparser):
+    sp = subparser.add_parser('get-all', help='Get all configurations')
+    sp.set_defaults(func=integrations_coralogix_get_all)
+
+def integrations_coralogix_get_all(args):
+    get("/api/v1/coralogix/configurations")
+
+def subparser_integrations_coralogix_get_default(subparser):
+    sp = subparser.add_parser('get-default', help='Get default configuration')
+    sp.set_defaults(func=integrations_coralogix_get_default)
+
+def integrations_coralogix_get_default(args):
+    get("/api/v1/coralogix/default-configuration")
+
+def subparser_integrations_coralogix_update(subparser):
+    sp = subparser.add_parser('update', help='WARNING: Updating aliases for configurations or changing the default configuration could cause entity YAMLs that use this integration to break.')
+    add_argument_alias(sp)
+    add_argument_file(sp, 'File containing JSON-formatted coralogix configuration')
+    sp.set_defaults(func=integrations_coralogix_update)
+
+def integrations_coralogix_update(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    put("/api/v1/coralogix/configuration/" + args.alias, headers, payload=read_file(args))
+
+def subparser_integrations_coralogix_validate(subparser):
+    sp = subparser.add_parser('validate', help='Validate a single configurations')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_coralogix_validate)
+
+def integrations_coralogix_validate(args):
+    post("/api/v1/coralogix/configuration/validate/" + args.alias)
+
+def subparser_integrations_coralogix_validate_all(subparser):
+    sp = subparser.add_parser('validate-all', help='Validate all configurations')
+    sp.set_defaults(func=integrations_coralogix_validate_all)
+
+def integrations_coralogix_validate_all(args):
+    post("/api/v1/coralogix/configuration/validate")
+# Integrations-coralogix end
 
 # Integrations-github start
 def subparser_integrations_github_opts(subparser):
@@ -2068,6 +2190,115 @@ def subparser_integrations_datadog_validate_all(subparser):
 def integrations_datadog_validate_all(args):
     post("/api/v1/datadog/configuration/validate")
 # Integrations-datadog end
+
+# Integrations-launchdarkly start
+def subparser_integrations_launchdarkly_opts(subparser):
+    sp = subparser.add_subparsers(help='integrations - launchdarkly help')
+
+    subparser_integrations_launchdarkly_add(sp)
+    subparser_integrations_launchdarkly_add_multiple(sp)
+    subparser_integrations_launchdarkly_delete(sp)
+    subparser_integrations_launchdarkly_delete_all(sp)
+    subparser_integrations_launchdarkly_get(sp)
+    subparser_integrations_launchdarkly_get_all(sp)
+    subparser_integrations_launchdarkly_get_default(sp)
+    subparser_integrations_launchdarkly_update(sp)
+    subparser_integrations_launchdarkly_validate(sp)
+    subparser_integrations_launchdarkly_validate_all(sp)
+
+def subparser_integrations_launchdarkly_add(subparser):
+    sp = subparser.add_parser('add', help='Add a single configuration')
+    add_argument_file(sp, 'File containing JSON-formatted launchdarkly configuration')
+    sp.set_defaults(func=integrations_launchdarkly_add)
+
+def integrations_launchdarkly_add(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    post("/api/v1/launchdarkly/configuration/", headers, payload=read_file(args))
+
+def subparser_integrations_launchdarkly_add_multiple(subparser):
+    sp = subparser.add_parser('add-multiple', 
+            help='Add multiple configurations', 
+            formatter_class=argparse.RawTextHelpFormatter, 
+            epilog=textwrap.dedent('''\
+                Format of JSON-formatted configuration file:
+                --------------------------------------------
+                {
+                  "accountId": 0,
+                  "alias": "string",
+                  "isDefault": true,
+                  "personalKey": "string",
+                  "region": "US"
+                }
+                '''))
+    add_argument_file(sp, 'File containing JSON-formatted launchdarkly configurations')
+    sp.set_defaults(func=integrations_launchdarkly_add_multiple)
+
+def integrations_launchdarkly_add_multiple(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    post("/api/v1/launchdarkly/configurations", headers, payload=read_file(args))
+
+def subparser_integrations_launchdarkly_delete(subparser):
+    sp = subparser.add_parser('delete', help='Delete a single configuration')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_launchdarkly_delete)
+
+def integrations_launchdarkly_delete(args):
+    delete("/api/v1/launchdarkly/configuration/" + args.alias)
+
+def subparser_integrations_launchdarkly_delete_all(subparser):
+    sp = subparser.add_parser('delete-all', help='Delete all configurations')
+    sp.set_defaults(func=integrations_launchdarkly_delete_all)
+
+def integrations_launchdarkly_delete_all(args):
+    delete("/api/v1/launchdarkly/configurations")
+
+def subparser_integrations_launchdarkly_get(subparser):
+    sp = subparser.add_parser('get', help='Get a single configuration')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_launchdarkly_get)
+
+def integrations_launchdarkly_get(args):
+    get("/api/v1/launchdarkly/configuration/" + args.alias)
+
+def subparser_integrations_launchdarkly_get_all(subparser):
+    sp = subparser.add_parser('get-all', help='Get all configurations')
+    sp.set_defaults(func=integrations_launchdarkly_get_all)
+
+def integrations_launchdarkly_get_all(args):
+    get("/api/v1/launchdarkly/configurations")
+
+def subparser_integrations_launchdarkly_get_default(subparser):
+    sp = subparser.add_parser('get-default', help='Get default configuration')
+    sp.set_defaults(func=integrations_launchdarkly_get_default)
+
+def integrations_launchdarkly_get_default(args):
+    get("/api/v1/launchdarkly/default-configuration")
+
+def subparser_integrations_launchdarkly_update(subparser):
+    sp = subparser.add_parser('update', help='WARNING: Updating aliases for configurations or changing the default configuration could cause entity YAMLs that use this integration to break.')
+    add_argument_alias(sp)
+    add_argument_file(sp, 'File containing JSON-formatted launchdarkly configuration')
+    sp.set_defaults(func=integrations_launchdarkly_update)
+
+def integrations_launchdarkly_update(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    put("/api/v1/launchdarkly/configuration/" + args.alias, headers, payload=read_file(args))
+
+def subparser_integrations_launchdarkly_validate(subparser):
+    sp = subparser.add_parser('validate', help='Validate a single configurations')
+    add_argument_alias(sp)
+    sp.set_defaults(func=integrations_launchdarkly_validate)
+
+def integrations_launchdarkly_validate(args):
+    post("/api/v1/launchdarkly/configuration/validate/" + args.alias)
+
+def subparser_integrations_launchdarkly_validate_all(subparser):
+    sp = subparser.add_parser('validate-all', help='Validate all configurations')
+    sp.set_defaults(func=integrations_launchdarkly_validate_all)
+
+def integrations_launchdarkly_validate_all(args):
+    post("/api/v1/launchdarkly/configuration/validate")
+# Integrations-launchdarkly end
 
 # Integrations-newrelic start
 def subparser_integrations_newrelic_opts(subparser):

--- a/poetry.lock
+++ b/poetry.lock
@@ -386,6 +386,25 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use-chardet-on-py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "responses"
+version = "0.24.1"
+description = "A utility library for mocking out the `requests` Python library."
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "responses-0.24.1-py3-none-any.whl", hash = "sha256:a2b43f4c08bfb9c9bd242568328c65a34b318741d3fab884ac843c5ceeb543f9"},
+    {file = "responses-0.24.1.tar.gz", hash = "sha256:b127c6ca3f8df0eb9cc82fd93109a3007a86acb24871834c47b77765152ecf8c"},
+]
+
+[package.dependencies]
+pyyaml = "*"
+requests = ">=2.30.0,<3.0"
+urllib3 = ">=1.25.10,<3.0"
+
+[package.extras]
+tests = ["coverage (>=6.0.0)", "flake8", "mypy", "pytest (>=7.0.0)", "pytest-asyncio", "pytest-cov", "pytest-httpserver", "tomli", "tomli-w", "types-PyYAML", "types-requests"]
+
+[[package]]
 name = "urllib3"
 version = "2.0.7"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
@@ -405,4 +424,4 @@ zstd = ["zstandard (>=0.18.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.11"
-content-hash = "dc416164e790748ca7aa7f8b4d9a4f38fe4958d6415edbe6d5d1bc206fcc216b"
+content-hash = "3c8d1cf9d910ca74b8242c71c062689062ee791f1ecda9411f347d98e4fcc3f4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ pytest-cov = "^4.1.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest-xdist = "^3.4.0"
+responses = "^0.24.1"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tests/test_integrations_coralogix.py
+++ b/tests/test_integrations_coralogix.py
@@ -1,0 +1,69 @@
+"""
+Tests for coralogix integration commands.
+"""
+from cortexapps_cli.cortex import cli
+from string import Template
+import json
+import os
+import pytest
+import responses
+
+coralogix_api_key = json.dumps("fakeKey")
+
+def _coralogix_input(tmp_path):
+    f = tmp_path / "test_integrations_coralogix_add.json"
+    template = Template("""
+        {
+          "alias": "test",
+          "apiKey": ${coralogix_api_key},
+          "isDefault": true,
+          "region": "US1"
+        }
+        """)
+    content = template.substitute(coralogix_api_key=coralogix_api_key)
+    f.write_text(content)
+    return f
+
+def test_integrations_coralogix_add(tmp_path):
+    f = _coralogix_input(tmp_path)
+
+    cli(["integrations", "coralogix", "delete-all"])
+    cli(["integrations", "coralogix", "add", "-f", str(f)])
+    cli(["integrations", "coralogix", "get", "-a", "test"])
+    cli(["integrations", "coralogix", "get-all"])
+    cli(["integrations", "coralogix", "get-default"])
+
+    cli(["integrations", "coralogix", "update", "-a", "test", "-f", str(f)])
+    cli(["integrations", "coralogix", "delete", "-a", "test"])
+
+    f = tmp_path / "test_integrations_coralogix_update_multiple.json"
+    template = Template("""
+        {
+          "configurations": [
+            {
+              "alias": "test",
+              "apiKey": ${coralogix_api_key},
+              "isDefault": true,
+              "region": "US1"
+            },
+            {
+              "alias": "test-2",
+              "apiKey": ${coralogix_api_key},
+              "isDefault": true,
+              "region": "US2"
+            }
+          ]
+        }
+        """)
+    content = template.substitute(coralogix_api_key=coralogix_api_key)
+    f.write_text(content)
+    cli(["integrations", "coralogix", "add-multiple", "-f", str(f)])
+    cli(["integrations", "coralogix", "delete-all"])
+
+@responses.activate
+def test_integrations_coralogix_validate(tmp_path):
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/coralogix/configuration/validate/test", json={'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}, status=200)
+    cli(["integrations", "coralogix", "validate", "-a", "test"])
+
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/coralogix/configuration/validate", json=[ { 'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}], status=200)
+    cli(["integrations", "coralogix", "validate-all"])

--- a/tests/test_integrations_launchdarkly.py
+++ b/tests/test_integrations_launchdarkly.py
@@ -1,0 +1,69 @@
+"""
+Tests for launchdarkly integration commands.
+"""
+from cortexapps_cli.cortex import cli
+from string import Template
+import json
+import os
+import pytest
+import responses
+
+launchdarkly_api_key = json.dumps("fakeKey")
+
+def _launchdarkly_input(tmp_path):
+    f = tmp_path / "test_integrations_launchdarkly_add.json"
+    template = Template("""
+        {
+          "alias": "test",
+          "apiKey": ${launchdarkly_api_key},
+          "environment": "DEFAULT",
+          "isDefault": true
+        }
+        """)
+    content = template.substitute(launchdarkly_api_key=launchdarkly_api_key)
+    f.write_text(content)
+    return f
+
+def test_integrations_launchdarkly_add(tmp_path):
+    f = _launchdarkly_input(tmp_path)
+
+    cli(["integrations", "launchdarkly", "delete-all"])
+    cli(["integrations", "launchdarkly", "add", "-f", str(f)])
+    cli(["integrations", "launchdarkly", "get", "-a", "test"])
+    cli(["integrations", "launchdarkly", "get-all"])
+    cli(["integrations", "launchdarkly", "get-default"])
+
+    cli(["integrations", "launchdarkly", "update", "-a", "test", "-f", str(f)])
+    cli(["integrations", "launchdarkly", "delete", "-a", "test"])
+
+    f = tmp_path / "test_integrations_launchdarkly_update_multiple.json"
+    template = Template("""
+        {
+          "configurations": [
+            {
+              "alias": "test",
+              "apiKey": ${launchdarkly_api_key},
+              "environment": "DEFAULT",
+              "isDefault": true
+            },
+            {
+              "alias": "test-2",
+              "apiKey": ${launchdarkly_api_key},
+              "environment": "FEDERAL",
+              "isDefault": false
+            }
+          ]
+        }
+        """)
+    content = template.substitute(launchdarkly_api_key=launchdarkly_api_key)
+    f.write_text(content)
+    cli(["integrations", "launchdarkly", "add-multiple", "-f", str(f)])
+    cli(["integrations", "launchdarkly", "delete-all"])
+
+@responses.activate
+def test_integrations_launchdarkly_validate(tmp_path):
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/launchdarkly/configuration/validate/test", json={'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}, status=200)
+    cli(["integrations", "launchdarkly", "validate", "-a", "test"])
+
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/launchdarkly/configuration/validate", json=[ { 'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}], status=200)
+    cli(["integrations", "launchdarkly", "validate-all"])

--- a/tests/test_integrations_newrelic.py
+++ b/tests/test_integrations_newrelic.py
@@ -7,9 +7,10 @@ import json
 import os
 import pytest
 import responses
+import sys
 
-newrelic_account_id = os.getenv('NEWRELIC_ACCOUNT_ID')
-newrelic_personal_key = os.getenv('NEWRELIC_PERSONAL_KEY')
+newrelic_account_id = 123
+newrelic_personal_key = json.dumps("fakeKey")
 
 def _newrelic_input(tmp_path):
     f = tmp_path / "test_integrations_newrelic_add.json"
@@ -18,11 +19,12 @@ def _newrelic_input(tmp_path):
           "accountId": ${newrelic_account_id},
           "alias": "test",
           "isDefault": true,
-          "personalKey": "${newrelic_personal_key}",
+          "personalKey": ${newrelic_personal_key},
           "region": "US"
         }
         """)
     content = template.substitute(newrelic_account_id=newrelic_account_id, newrelic_personal_key=newrelic_personal_key)
+    sys.stdout.write(content)
     f.write_text(content)
     return f
 
@@ -46,14 +48,14 @@ def test_integrations_newrelic_add(tmp_path):
              "accountId": ${newrelic_account_id},
              "alias": "test-1",
              "isDefault": false,
-             "personalKey": "${newrelic_personal_key}",
+             "personalKey": ${newrelic_personal_key},
              "region": "US"
            },
            {
              "accountId": ${newrelic_account_id},
              "alias": "test-2",
              "isDefault": false,
-             "personalKey": "${newrelic_personal_key}",
+             "personalKey": ${newrelic_personal_key},
              "region": "US"
            }
           ]

--- a/tests/test_integrations_sonarqube.py
+++ b/tests/test_integrations_sonarqube.py
@@ -3,8 +3,10 @@ Tests for sonarqube integration commands.
 """
 from cortexapps_cli.cortex import cli
 from string import Template
+import json
 import os
 import pytest
+import responses
 
 sonarqube_host = os.getenv('SONARQUBE_HOST')
 sonarqube_personal_token = os.getenv('SONARQUBE_PERSONAL_TOKEN')
@@ -63,11 +65,10 @@ def test_integrations_sonarqube(tmp_path):
     f.write_text(content)
     cli(["integrations", "sonarqube", "add-multiple", "-f", str(f)])
 
-@pytest.mark.skip(reason="Skipping until I can figure out how to install community sonarqube and use ngrok3")
+@responses.activate
 def test_integrations_sonarqube_validate():
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/sonarqube/configuration/validate/cortex-test", json={'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}, status=200)
     cli(["integrations", "sonarqube", "validate", "-a", "cortex-test"])
 
-@pytest.mark.skip(reason="Skipping until I can figure out how to install community sonarqube and use ngrok3")
-def test_integrations_sonarqube_validate_all():
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/sonarqube/configuration/validate", json={'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}, status=200)
     cli(["integrations", "sonarqube", "validate-all"])
-

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -22,7 +22,7 @@ def _ip_allowlist_input(tmp_path):
     f.write_text(content)
     return f
 
-def test_ip_allowlist():
+def test_ip_allowlist(tmp_path):
     cli(["ip-allowlist", "get"])
 
     f = _ip_allowlist_input(tmp_path)

--- a/tests/test_ip_allowlist.py
+++ b/tests/test_ip_allowlist.py
@@ -22,16 +22,13 @@ def _ip_allowlist_input(tmp_path):
     f.write_text(content)
     return f
 
-def test_ip_allowlist_get():
+def test_ip_allowlist():
     cli(["ip-allowlist", "get"])
 
-def test_ip_allowlist_validate(tmp_path):
     f = _ip_allowlist_input(tmp_path)
     cli(["ip-allowlist", "validate", "-f", str(f)])
 
-def test_ip_allowlist_replace(tmp_path):
     f = _ip_allowlist_input(tmp_path)
     cli(["ip-allowlist", "replace", "-f", str(f)])
 
-def test_ip_allowlist_empty():
     cli(["ip-allowlist", "replace", "-f", "tests/test_ip_allowlist_empty.json"])


### PR DESCRIPTION
This PR:
- adds support for the coralogix, launchdarkly integrations
- adds mock tests for newrelic and sonarqube so they no longer need to be skipped