### PR TITLE
Add error handling for bad API keys

### DIFF
--- a/tests/test_command_line_opts.py
+++ b/tests/test_command_line_opts.py
@@ -31,13 +31,3 @@ def test_integrations_command():
 def test_command_no_options():
     with pytest.raises(SystemExit) as excinfo:
         cli(["catalog"])
-
-def test_new_config_file(tmp_path):
-    f = tmp_path / "cortex_config"
-    content = """
-        [default]
-        api_key = REPLACE_WITH_YOUR_CORTEX_API_KEY
-        """
-    f.write_text(content)
-    with pytest.raises(SystemExit) as excinfo:
-        cli(["-c", str(f), "catalog", "list"])

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -4,12 +4,48 @@ Tests for the cortex CLI config file
 from cortexapps_cli.cortex import cli
 
 import io
+import os
 import pytest
 import sys
+from string import Template
 
 # Requires user input, so use monkeypatch to set it.
-def test_create_config_file(monkeypatch, tmp_path):
+def test_config_file_create(monkeypatch, tmp_path):
     with pytest.raises(SystemExit) as excinfo:
         monkeypatch.setattr('sys.stdin', io.StringIO('Y'))
         f = tmp_path / "test-config.txt"
         cli(["-c", str(f), "catalog", "list"])
+
+def test_config_file_new(tmp_path, capsys):
+    f = tmp_path / "cortex_config"
+    content = """
+        [default]
+        api_key = REPLACE_WITH_YOUR_CORTEX_API_KEY
+        """
+    f.write_text(content)
+    with pytest.raises(SystemExit) as excinfo:
+        cli(["-c", str(f), "teams", "list"])
+        out, err = capsys.readouterr()
+
+def test_config_file_api_key_quotes(tmp_path):
+    cortex_api_key = os.getenv('CORTEX_API_KEY')
+    f = tmp_path / "cortex_config_api_key_quotes"
+    template = Template("""
+        [default]
+        api_key = "${cortex_api_key}"
+        """)
+    content = template.substitute(cortex_api_key=cortex_api_key)
+    f.write_text(content)
+    cli(["-c", str(f), "teams", "list"])
+
+def test_config_file_bad_api_key(tmp_path, capsys):
+    f = tmp_path / "cortex_config_bad_api_key"
+    content = """
+        [default]
+        api_key = invalidApiKey
+        """
+    f.write_text(content)
+    with pytest.raises(SystemExit) as excinfo:
+        cli(["-c", str(f), "teams", "list"])
+        out, err = capsys.readouterr()
+        assert err.partition('\n')[0] == "Unauthorized", "Invalid api key should show Unauthorized message"


### PR DESCRIPTION
This PR implements our first fix from a customer reported issue -- https://github.com/cortexapps/cli/issues/20.

It does the following:
- if the user has quotes around their API key in their cortex config file, they are stripped off
- if the API key is invalid (results in a 401 error), a message like this will be displayed:
```
Unauthorized

Check your api_key in /Users/jeffschnitter/.cortex/config.
```