### PR TITLE
Add suffix for export directory

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,11 +1,23 @@
 Release History
 ===============
 
+0.10.0 (2023-11-21)
+------------------
+
+**Improvements**
+- For exports, add the cortex tenant - the value in the .cortex/config file that identifies the tenant.
+
+0.9.0 (2023-11-21)
+------------------
+
+**Improvements**
+- Better API key handling -- strip quotes from keys; add better error messages.
+
 0.8.0 (2023-11-19)
 ------------------
 
 **Improvements**
-- Add coralogx, launchdarkly integrations.
+- Add coralogix, launchdarkly integrations.
 
 0.7.0 (2023-11-17)
 ------------------

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
+[![PyPi version](https://badgen.net/pypi/v/cortexapps-cli/)](https://pypi.org/project/cortexapps-cli)
+[![PyPI download month](https://img.shields.io/pypi/dm/cortexapps-cli.svg)](https://pypi.python.org/pypi/cortexapps-cli/)
+[![PyPI license](https://img.shields.io/pypi/l/cortexapps-cli.svg)](https://pypi.python.org/pypi/cortexapps-cli/)
+[![PyPI pyversions](https://img.shields.io/pypi/pyversions/cortexapps-cli.svg)](https://pypi.python.org/pypi/cortexapps-cli/)
+
 # Cortex CLI
 
-**cortexapps-cli** implements a command line interface for cortexapps.
+**cortexapps-cli** implements a command line interface for [cortexapps](https://cortex.io).
 
 # Installation
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -262,6 +262,13 @@ def add_argument_export_directory(subparser):
             default=os.path.expanduser('~') + '/.cortex/export/' + datetime.now().strftime("%Y-%m-%d-%H-%M-%S"),
             metavar=''
     )
+    subparser.add_argument(
+            '-default-directory', 
+            '--default-directory', 
+            help=argparse.SUPPRESS,
+            required=False,
+            default=os.path.expanduser('~') + '/.cortex/export/' + datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    )
 
 def add_argument_file(subparser, help_text):
     subparser.add_argument(
@@ -646,6 +653,11 @@ def subparser_backup_export(subparser):
     sp.set_defaults(func=export)
 
 def export(args):
+    # https://github.com/cortexapps/cli/issues/21
+    # Cannot add this when option is added because we don't have the tenant yet.
+    if args.directory == args.default_directory:
+        args.directory = args.directory + "-" + args.tenant
+
     catalog_directory=args.directory + "/catalog"
     json_directory=args.directory + "/json"
     scorecard_directory=args.directory + "/scorecards"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,10 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.urls]
-homepage = "https://github.com/cortexapps/cli"
-"Bug Tracker" = "https://github.com/python-poetry/poetry/issues"
+Homepage = "https://github.com/cortexapps/cli"
+"Bug Tracker" = "https://github.com/cortexapps/cli/issues"
+"Changes" = " https://github.com/cortexapps/cli/blob/main/HISTORY.md"
+"Documentation" = " https://github.com/cortexapps/cli/blob/main/README.md"
 
 [tool.pytest.ini_options]
 minversion = "7.4.3"

--- a/tests/test_backup.py
+++ b/tests/test_backup.py
@@ -6,8 +6,13 @@ from cortexapps_cli.cortex import cli
 import pytest
 import sys
 
-def test_export():
+def test_export(capsys):
     cli(["-t", "rich-sandbox", "backup", "export"])
+    out, err = capsys.readouterr()
+    last_line = out.strip().split("\n")[-1]
+    sys.stdout.write(out + "\n\n")
+    sys.stdout.write(last_line + "\n\n")
+    assert "rich-sandbox" in out 
 
 def test_import(capsys):
     cli(["backup", "import", "-d", "tests/test_backup_export"])


### PR DESCRIPTION
This PR:
- adds a suffix to the default directory for the `cortex backup export` command.
- adds some small documentation fixes - adding badges to the README, links to the documentation on pypi.org