### PR TITLE
One more try -- fix logic in workflow to ensure pypi triggers docker workflow

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,6 +1,7 @@
 name: Publish to hub.docker.com
 
 on:
+  workflow_dispatch:
   workflow_run:
     workflows:
       - [Publish to pypi.org]
@@ -21,9 +22,8 @@ jobs:
 
     - name: checkout source
       uses: actions/checkout@v3
-
-    - name: Get tags
-      run: git fetch --tags origin
+      with:
+        fetch-tags: true
 
     - name: Get version
       run: |

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -7,6 +7,7 @@ on:
     paths:
       - 'cortexapps_cli/cortex.py'
       - '.github/workflows/publish-pypi.yml'
+      - '.github/workflows/publish-docker.yml'
 
 env:
   CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY_PRODUCTION }}


### PR DESCRIPTION
### This PR
Makes another attempt to fix workflow logic.  The publish to pypi workflow needs to also trigger when changes are made to the docker workflow since they are chained.

It also changes the docker workflow to fetch tags as part of the checkout.