### PR TITLE
Make docker job dependent on pypi job in order for git tag to be updated

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
         type:        "DEPLOY"
         url:         "${{ env.URL }}"
   docker:
+    needs: pypi
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### This PR
GitHub actions can be tricky to test!  The previous workflow failed because the git tag already existed.  We already published version 0.11.0.  Something must have gotten a bit wonky with the numerous PRs I've pushed over the last couple of days.

Additionally, the docker job was triggered in parallel with the pypi job.  This job needs to run after the pypi job because the first job bumps the version and applies a new git tag.  The docker job retrieves this tag in order to get the version.