### PR TITLE
Add support for updating deploys by uuid

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,8 +6,7 @@ on:
       - main
     paths:
       - 'cortexapps_cli/cortex.py'
-      - '.github/workflows/publish-pypi.yml'
-      - '.github/workflows/publish-docker.yml'
+      - '.github/workflows/publish.yml'
 
 env:
   CORTEX_API_KEY: ${{ secrets.CORTEX_API_KEY_PRODUCTION }}
@@ -47,6 +46,10 @@ jobs:
 
     - name: Set variables needed for Cortex deploy API
       run: |
+         author=$(echo "$GITHUB_CONTEXT" | jq -r ".event.head_commit.author.name")
+         email=$(echo "$GITHUB_CONTEXT" | jq -r ".event.head_commit.author.email")
+         echo "AUTHOR=${author}" >> $GITHUB_ENV
+         echo "EMAIL=${email}" >> $GITHUB_ENV
          echo "SHA=$(sha256sum dist/*.tar.gz | awk '{ print $1 }')" >> $GITHUB_ENV
          echo "URL=https://pypi.org/project/cortexapps-cli/${{ env.VERSION }}/" >> $GITHUB_ENV
 
@@ -54,12 +57,14 @@ jobs:
     - name: Post pypi deploy event to Cortex
       uses: ./.github/actions/cortex-deploys
       with:
-        tag:         "cli"
-        environment: "PyPI.org"
-        sha:         "${{ env.SHA }}"
-        title:       "${{ env.VERSION }}"
-        type:        "DEPLOY"
-        url:         "${{ env.URL }}"
+        deployer-email: "${{ env.EMAIL }}"
+        deployer-name:  "${{ env.AUTHOR }}"
+        environment:    "PyPI.org"
+        sha:            "${{ env.SHA }}"
+        tag:            "cli"
+        title:          "${{ env.VERSION }}"
+        type:           "DEPLOY"
+        url:            "${{ env.URL }}"
   docker:
     needs: pypi
     runs-on: ubuntu-latest

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -1473,10 +1473,12 @@ def subparser_deploys_opts(subparsers):
     sp = p.add_subparsers(help='deploys help')
 
     subparser_deploys_add(sp)
-    subparser_deploys_list(sp)
     subparser_deploys_delete(sp)
     subparser_deploys_delete_all(sp)
+    subparser_deploys_delete_by_uuid(sp)
     subparser_deploys_delete_filter(sp)
+    subparser_deploys_list(sp)
+    subparser_deploys_update_by_uuid(sp)
 
 def subparser_deploys_add(subparser):
     sp = subparser.add_parser('add', help='Add a deployment to an entity')
@@ -1514,6 +1516,15 @@ def subparser_deploys_delete_all(subparser):
 def deploys_delete_all(args):
     delete("/api/v1/catalog/deploys/all")
 
+def subparser_deploys_delete_by_uuid(subparser):
+    sp = subparser.add_parser('delete-by-uuid', help='Delete deployment by UUID')
+    add_argument_tag(sp)
+    add_argument_uuid(sp, help_text="UUID of deploy to delete")
+    sp.set_defaults(func=deploys_delete_by_uuid)
+
+def deploys_delete_by_uuid(args):
+    delete("/api/v1/catalog/" + args.tag + "/deploys/" + args.uuid)
+
 def subparser_deploys_delete_filter(subparser):
     sp = subparser.add_parser('delete-filter', help='Delete deployments for all entities based on a filter')
     add_argument_environment(sp)
@@ -1523,6 +1534,17 @@ def subparser_deploys_delete_filter(subparser):
 
 def deploys_delete_filter(args):
     delete("/api/v1/catalog/deploys" + parse_opts(args))
+
+def subparser_deploys_update_by_uuid(subparser):
+    sp = subparser.add_parser('update-by-uuid', help='Update deployment by UUID')
+    add_argument_file(sp, 'File containing JSON-formatted deployment details')
+    add_argument_tag(sp)
+    add_argument_uuid(sp, help_text="UUID of deploy to update")
+    sp.set_defaults(func=deploys_update_by_uuid)
+
+def deploys_update_by_uuid(args):
+    headers = { 'Content-Type': 'application/json;charset=UTF-8' }
+    put("/api/v1/catalog/" + args.tag + "/deploys/" + args.uuid, headers, payload=read_file(args))
 # Deploys end
 
 # Discovery Audit start
@@ -2395,7 +2417,7 @@ def subparser_integrations_newrelic_add(subparser):
 
 def integrations_newrelic_add(args):
     headers = { 'Content-Type': 'application/json;charset=UTF-8' }
-    post("/api/v1/newrelic/configuration/", headers, payload=read_file(args))
+    post("/api/v1/newrelic/configuration", headers, payload=read_file(args))
 
 def subparser_integrations_newrelic_add_multiple(subparser):
     sp = subparser.add_parser('add-multiple', 

--- a/tests/test_deploys.py
+++ b/tests/test_deploys.py
@@ -2,19 +2,31 @@
 Tests for deploys commands.
 """
 from cortexapps_cli.cortex import cli
+import json
 
 def _add_deploy():
     cli(["deploys", "add", "-t", "cli-test-service", "-f", "tests/test_deploys.json"])
 
-def test_deploys():
+def test_deploys(capsys):
+    # This has to be the first call to the cli because we want to capture the output and capsys
+    # captures output collectively.
+    cli(["deploys", "add", "-t", "cli-test-service", "-f", "tests/test_deploys_uuid.json"])
+    out, err = capsys.readouterr()
+    out = json.loads(out)
+    uuid = out['uuid']
+
+    cli(["-d", "deploys", "update-by-uuid", "-t", "cli-test-service", "-u", uuid, "-f", "tests/test_deploys_update.json"])
+
+    cli(["deploys", "delete-by-uuid", "-t", "cli-test-service", "-u", uuid])
+
     _add_deploy()
 
     cli(["deploys", "list", "-t", "cli-test-service"])
 
     cli(["deploys", "delete", "-t", "cli-test-service", "-s", "SHA-123456"])
-    _add_deploy()
 
+    _add_deploy()
     cli(["deploys", "delete-filter", "-y", "DEPLOY"])
-    _add_deploy()
 
+    _add_deploy()
     cli(["deploys", "delete-all"])

--- a/tests/test_deploys_update.json
+++ b/tests/test_deploys_update.json
@@ -1,0 +1,14 @@
+{
+  "customData": {
+     "test-field-1": "value1"
+  },
+  "deployer": {
+    "email": "test-user@example.com",
+    "name": "Test Deployer"
+  },
+  "environment": "testEnv",
+  "sha": "SHA-456789",
+  "timestamp": "2023-11-29T22:55:38.284Z",
+  "title": "deploy-001",
+  "type": "DEPLOY"
+}

--- a/tests/test_deploys_uuid.json
+++ b/tests/test_deploys_uuid.json
@@ -1,0 +1,14 @@
+{
+  "customData": {
+     "test-field-2": "value2"
+  },
+  "deployer": {
+    "email": "test-user@example.com",
+    "name": "Test Deployer"
+  },
+  "environment": "testEnv",
+  "sha": "SHA-999999",
+  "timestamp": "2023-11-29T16:29:38.284Z",
+  "title": "deploy-002",
+  "type": "DEPLOY"
+}

--- a/tests/test_integrations_newrelic.py
+++ b/tests/test_integrations_newrelic.py
@@ -1,75 +1,68 @@
 """
 Tests for newrelic integration commands.
+
+These tests all use mock responses.
 """
 from cortexapps_cli.cortex import cli
-from string import Template
 import json
-import os
-import pytest
 import responses
-import sys
 
-newrelic_account_id = 123
-newrelic_personal_key = json.dumps("fakeKey")
-
-def _newrelic_input(tmp_path):
+# Since responses are all mocked and no data validation is done by the CLI --
+# we let the API handle validation -- we don't need valid input files.
+def _dummy_file(tmp_path):
     f = tmp_path / "test_integrations_newrelic_add.json"
-    template = Template("""
-        {
-          "accountId": ${newrelic_account_id},
-          "alias": "test",
-          "isDefault": true,
-          "personalKey": ${newrelic_personal_key},
-          "region": "US"
-        }
-        """)
-    content = template.substitute(newrelic_account_id=newrelic_account_id, newrelic_personal_key=newrelic_personal_key)
-    sys.stdout.write(content)
-    f.write_text(content)
+    f.write_text("foobar")
     return f
 
+@responses.activate
 def test_integrations_newrelic_add(tmp_path):
-    f = _newrelic_input(tmp_path)
-
-    cli(["integrations", "newrelic", "delete-all"])
+    f = _dummy_file(tmp_path)
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/newrelic/configuration", json=[{'accountId': 123, 'alias:': 'test', 'isDefault': json.dumps("true"), 'personalKey': 'xxxx', 'region': 'US'}], status=200)
     cli(["integrations", "newrelic", "add", "-f", str(f)])
-    cli(["integrations", "newrelic", "get", "-a", "test"])
-    cli(["integrations", "newrelic", "get-all"])
-    cli(["integrations", "newrelic", "get-default"])
 
-    cli(["integrations", "newrelic", "update", "-a", "test", "-f", str(f)])
+@responses.activate
+def test_integrations_newrelic_add_multiple(tmp_path):
+    f = _dummy_file(tmp_path)
+    responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/newrelic/configurations", json=[{'accountId': 123, 'alias:': 'test', 'isDefault': json.dumps("true"), 'personalKey': 'xxxx', 'region': 'US'}], status=200)
+    cli(["integrations", "newrelic", "add-multiple", "-f", str(f)])
+
+@responses.activate
+def test_integrations_newrelic_delete():
+    responses.add(responses.DELETE, "https://api.getcortexapp.com/api/v1/newrelic/configuration/test", status=200)
     cli(["integrations", "newrelic", "delete", "-a", "test"])
 
-    f = tmp_path / "test_integrations_newrelic_update_multiple.json"
-    template = Template("""
-        {
-          "configurations": [
-           {
-             "accountId": ${newrelic_account_id},
-             "alias": "test-1",
-             "isDefault": false,
-             "personalKey": ${newrelic_personal_key},
-             "region": "US"
-           },
-           {
-             "accountId": ${newrelic_account_id},
-             "alias": "test-2",
-             "isDefault": false,
-             "personalKey": ${newrelic_personal_key},
-             "region": "US"
-           }
-          ]
-        }
-        """)
-    content = template.substitute(newrelic_account_id=newrelic_account_id, newrelic_personal_key=newrelic_personal_key)
-    f.write_text(content)
-    cli(["integrations", "newrelic", "add-multiple", "-f", str(f)])
+@responses.activate
+def test_integrations_newrelic_delete_all():
+    responses.add(responses.DELETE, "https://api.getcortexapp.com/api/v1/newrelic/configurations", status=200)
     cli(["integrations", "newrelic", "delete-all"])
 
 @responses.activate
-def test_integrations_newrelic_validate(tmp_path):
+def test_integrations_newrelic_get():
+    responses.add(responses.GET, "https://api.getcortexapp.com/api/v1/newrelic/configuration/test", json=[{'accountId': 123, 'alias:': 'test', 'isDefault': json.dumps("true"), 'personalKey': 'xxxx', 'region': 'US'}], status=200)
+    cli(["integrations", "newrelic", "get", "-a", "test"])
+
+@responses.activate
+def test_integrations_newrelic_get_all():
+    responses.add(responses.GET, "https://api.getcortexapp.com/api/v1/newrelic/configurations", json=[{'accountId': 123, 'alias:': 'test', 'isDefault': json.dumps("true"), 'personalKey': 'xxxx', 'region': 'US'}], status=200)
+    cli(["integrations", "newrelic", "get-all"])
+
+@responses.activate
+def test_integrations_newrelic_get_default():
+    responses.add(responses.GET, "https://api.getcortexapp.com/api/v1/newrelic/default-configuration", json=[{'accountId': 123, 'alias:': 'test', 'isDefault': json.dumps("true"), 'personalKey': 'xxxx', 'region': 'US'}], status=200)
+    cli(["integrations", "newrelic", "get-default"])
+
+@responses.activate
+def test_integrations_newrelic_update(tmp_path):
+    f = _dummy_file(tmp_path)
+    responses.add(responses.PUT, "https://api.getcortexapp.com/api/v1/newrelic/configuration/test", json=[{'alias:': 'test', 'isDefault': json.dumps("true")}], status=200)
+    cli(["integrations", "newrelic", "update", "-a", "test", "-f", str(f)])
+
+@responses.activate
+def test_integrations_newrelic_validate():
     responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/newrelic/configuration/validate/test", json={'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}, status=200)
     cli(["integrations", "newrelic", "validate", "-a", "test"])
 
+@responses.activate
+def test_integrations_newrelic_validate_all():
     responses.add(responses.POST, "https://api.getcortexapp.com/api/v1/newrelic/configuration/validate", json=[ { 'alias': 'test', 'isValid': json.dumps("true"), 'message': 'someMessage'}], status=200)
     cli(["integrations", "newrelic", "validate-all"])


### PR DESCRIPTION
### This PR
- Adds  'deploys update-by-uuid'
- Adds 'deploys delete-by-uuid'
- Changes the deploy event sent to Cortex to use the git committer email and user (needed for deploys to appear in eng intellgence)
- Modifies newrelic tests to use mocks

### Notes
The real driver for this PR was to ensure that publishing works for docker, but I needed to push some actual changes for that.

While testing locally, I found that 'integrations newrelic add' was failing.  The test was using a dummy account id and dummy personal API key.  It seems that the behavior of the API has changed to validate the newrelic API key, so I ended up modifying all newrelic tests to use mocks.