### PR TITLE
tag docker image with latest

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -41,6 +41,8 @@ jobs:
 
     - name: Git details about version
       id: git-details
+      env:
+        GITHUB_CONTEXT: ${{ toJson(github) }}
       run: |
          version=$(git describe --tags --abbrev=0)
          echo "VERSION=${version}" >> $GITHUB_ENV
@@ -94,6 +96,7 @@ jobs:
         echo "PUSHER=${PUSHER}" >> $GITHUB_ENV
         echo "VERSION=${VERSION}" >> $GITHUB_ENV
         echo "DOCKER_IMAGE=${{ env.DOCKER_USERNAME }}/cli:${VERSION}" >> $GITHUB_ENV
+        echo "DOCKER_IMAGE_LATEST=${{ env.DOCKER_USERNAME }}/cli:latest" >> $GITHUB_ENV
 
     - name: build docker image
       working-directory: ./docker
@@ -115,17 +118,38 @@ jobs:
     - name: push docker image
       run: |
         docker login -u ${{ env.DOCKER_USERNAME }} -p ${{ env.DOCKER_PASSWORD }}
+        docker tag ${{ env.DOCKER_IMAGE }} ${{ env.DOCKER_IMAGE_LATEST }}
         docker push ${{ env.DOCKER_IMAGE }}
+        docker push ${{ env.DOCKER_IMAGE_LATEST }}
 
-    - uses: actions/checkout@v4
+  docker-deploy-event:
+    needs: docker
+    runs-on: ubuntu-latest
+    container:
+      image: jeffschnittercortex/cli:latest
+    steps:
+
     - name: Post docker deploy event to Cortex
-      uses: ./.github/actions/cortex-deploys
-      with:
-        deployer-email: "${{ env.EMAIL }}"
-        deployer-name:  "${{ env.PUSHER }}"
-        environment:    "docker"
-        sha:            "${{ env.DOCKER_SHA }}"
-        tag:            "cli"
-        title:          "${{ env.VERSION }}"
-        type:           "DEPLOY"
-        url:            "${{ env.URL }}"
+      env:
+        EMAIL:   ${{needs.pypi.outputs.EMAIL}}
+        PUSHER:  ${{needs.pypi.outputs.PUSHER}}
+        SHA:     ${{needs.docker.outputs.SHA}}
+        URL:     ${{needs.docker.outputs.URL}}
+        VERSION: ${{needs.pypi.outputs.VERSION}}
+      run: |
+        cat << EOF > /tmp/deploy.json
+        {
+          "customData": {},
+          "deployer": {
+            "email": "${{ env.EMAIL }}",
+            "name": "${{ env.PUSHER }}"
+          },
+          "environment": "docker",
+          "sha": "       ${{ env.SHA }}",
+          "timestamp":   "$(date +'%Y-%m-%dT%H:%M:%S').000Z",
+          "title":       "${{ env.VERSION }}",
+          "type":        "DEPLOY",
+          "url":         "${{ env.URL }}"
+        }
+        EOF
+        cortex deploys add -t cli -f /tmp/deploy.json

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,13 @@
 Release History
 ===============
 
+0.15.0 (2023-12-05)
+------------------
+
+**Improvements**
+- use cortexapps CLI docker image for writing Cortex deploy events
+- tag docker image with latest and version tag 
+
 0.14.0 (2023-12-01)
 ------------------
 


### PR DESCRIPTION
### This PR
- tags the docker image with a latest tag in addition to the version tag
- Uses the docker image to create the Cortex deploy event, rather than the composite GitHub action
- Adds a fix to ensure we get the proper github context JSON object so it can be inspected to get the user who pushed the branch to main.  This user will be used as the deployer in the Cortex deploy event.

There really is no good way to test this without publishing an image.  If I try to test locally, it will publish to dockerhub.  I have tested pieces of this, like the use of the docker image in a test workflow.