### PR TITLE
Add showDrafts query parameter for scorecards list

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.21.0 (2024-01-25)
+------------------
+
+**Improvements**
+- Add showDrafts option to scorecards list
+
 0.20.0 (2024-01-22)
 ------------------
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -457,6 +457,15 @@ def add_argument_sha(subparser, help_text='The sha string of the deployment to d
             metavar=''
     )
 
+def add_argument_show_drafts(subparser, help_text='Include draft scorecards'):
+    subparser.add_argument(
+            '-s',
+            '--showDrafts',
+            help=help_text,
+            required=False,
+            action='store_true'
+    )
+
 def add_argument_start_time(subparser, help_text='Start time for audit log retrieve'):
     subparser.add_argument(
             '-s',
@@ -3721,10 +3730,11 @@ def scorecards_delete(args):
 
 def subparser_scorecards_list(subparser):
     sp = subparser.add_parser('list', help='List scorecards')
+    add_argument_show_drafts(sp)
     sp.set_defaults(func=scorecards_list)
 
 def scorecards_list(args):
-    get("/api/v1/scorecards")
+    get("/api/v1/scorecards" + parse_opts(args))
 
 def subparser_scorecards_shields_io_badge(subparser):
     sp = subparser.add_parser('shield', help='Retrieve scorecard shields.io badge')

--- a/tests/data/scorecards/test-scorecard-draft.yaml
+++ b/tests/data/scorecards/test-scorecard-draft.yaml
@@ -1,0 +1,19 @@
+tag: test-scorecard-draft
+name: Test Scorecard Draft
+description: Used to test Cortex CLI
+draft: true
+ladder:
+  name: Default Ladder
+  levels:
+  - name: You Made It
+    rank: 1
+    description: "\"If you ain't first, you're last. -- Ricky Bobby\" -- Scott Mullin"
+    color: 7cf376
+rules:
+- title: Has Custom Data
+  expression: custom("testField") != null
+  weight: 1
+  level: You Made It
+filter:
+  query: entity_descriptor.info.`x-cortex-tag` = "cli-test-service"
+  category: SERVICE

--- a/tests/test_scorecards.py
+++ b/tests/test_scorecards.py
@@ -2,6 +2,7 @@
 Tests for scorecards commands.
 """
 from cortexapps_cli.cortex import cli
+import json
 
 def test_scorecards():
     cli(["scorecards", "create", "-f", "tests/test_scorecards.yaml"])
@@ -20,3 +21,14 @@ def test_scorecards():
     cli(["scorecards", "scores", "-t", "test-scorecard", "-e", "test-service"])
 
     cli(["scorecards", "scores", "-t", "test-scorecard"])
+
+def test_scorecards_drafts(capsys):
+    cli(["scorecards", "create", "-f", "tests/test_scorecards_draft.yaml"])
+    # Only capturing this so it doesn't show up in next call to capsys.
+    out, err = capsys.readouterr()
+
+    cli(["scorecards", "list", "-s"])
+    out, err = capsys.readouterr()
+
+    out = json.loads(out)
+    assert any(scorecard['tag'] == 'test-scorecard-draft' for scorecard in out['scorecards'])

--- a/tests/test_scorecards_draft.yaml
+++ b/tests/test_scorecards_draft.yaml
@@ -1,0 +1,19 @@
+tag: test-scorecard-draft
+name: Test Scorecard Draft
+description: Used to test Cortex CLI
+draft: true
+ladder:
+  name: Default Ladder
+  levels:
+  - name: You Made It
+    rank: 1
+    description: "\"If you ain't first, you're last. -- Ricky Bobby\" -- Scott Mullin"
+    color: 7cf376
+rules:
+- title: Has Custom Data
+  expression: custom("testField") != null
+  weight: 1
+  level: You Made It
+filter:
+  query: entity_descriptor.info.`x-cortex-tag` = "cli-test-service"
+  category: SERVICE


### PR DESCRIPTION
**This PR:**

Adds showDrafts as a query parameter for scorecards list.  This is needed for [documentation](https://support.getcortexapp.com/hc/en-us/articles/20882617525403-CQL-v2-0) helping customers migrate from CQL v1 to CQL v2.