### PR TITLE
Don't fail on REST errors during import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ eggs/
 htmlcov/
 coverage.json
 .github/workflows/test.yml
+.export

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,19 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Python Debugger: Current File",
+            "type": "debugpy",
+            "request": "launch",
+            "program": "${file}",
+            "args": [
+                "-t",
+                "local",
+            ],
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,9 @@
 Release History
 ===============
 
+0.24.2 (2024-02-28)
+- Don't fail imports on Duplicate
+
 0.24.1 (2024-02-14)
 ------------------
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -107,7 +107,7 @@ def check_config_file(config_file, replace_string):
 def get_config(config, args, argv, parser, replace_string):
     if os.environ.get('CORTEX_API_KEY'):
         if args.tenant:
-            print("WARNING: tenant setting overidden by CORTEX_API_KEY")
+            print("WARNING: tenant setting overidden by CORTEX_API_KEY", file=sys.stderr)
 
         cortex_base_url = os.environ.get('CORTEX_BASE_URL', default='https://api.getcortexapp.com')
         config.update({"url": cortex_base_url})

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -588,7 +588,7 @@ def exit(r, method, expected_rc=200, err=None):
             print(f'{method} {r.url} => {r.status_code} {r.reason}')
             print(err)
         
-        if not config.get('is_importing', False):
+        if not config.get('is_importing', False) or r.status_code != 409 or r.status_code != 400:
             sys.exit(r.status_code)
     else:
         debug_json(r, method)


### PR DESCRIPTION
Adds two things:

1. Centralizes header creation (future needs)
2. Prevents faiulre on import for things that already exist.

```
Export complete!
Contents available in ./export/prod-cortex
Importing prod tenant to local DB...
Importing resource definitions
-->  employee.json
Conflict
```