### PR TITLE
Update checkout and set up python actions to enable upgrade from Node.js 16 to Node.js 20

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
       URL:     ${{ steps.git-details.outputs.URL }}
       VERSION: ${{ steps.git-details.outputs.VERSION }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Bump version and push tag
       uses: anothrNick/github-tag-action@1.64.0
@@ -33,7 +33,7 @@ jobs:
         WITH_V: false
 
     - name: Set up Python 3.11
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
 
@@ -98,7 +98,7 @@ jobs:
       SHA:     ${{ steps.build-docker-image.outputs.SHA }}
       URL:     ${{ steps.build-docker-image.outputs.URL }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get version info
       env:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -25,9 +25,9 @@ jobs:
         #python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
         python-version: ["3.11"]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     # You can test your matrix by printing the current Python version

--- a/.github/workflows/validate-pr.yml
+++ b/.github/workflows/validate-pr.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Get changed files
       id: changed-files

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.26.1 (2024-05-06)
+------------------
+
+**Improvements**
+- Upgrade GH Actions from Node.js 16 to Node.js 20.
+
 0.26.0 (2024-05-06)
 ------------------
 


### PR DESCRIPTION
This is just a GH actions update to eliminate warnings that are appearing as annotations in each GH actions workflow.