### PR TITLE
includeHierarchyFields is a string, not a boolean

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.26.2 (2024-05-08)
+------------------
+
+**Bugfixes**
+- change includeHierarchyFields for catalog API to be string, not boolean
+
 0.26.1 (2024-05-06)
 ------------------
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -294,6 +294,15 @@ def add_argument_groups(subparser):
             metavar=''
     )
 
+def add_argument_hierarchyDepth(subparser):
+    subparser.add_argument(
+            '-d',
+            '--hierarchy-depth',
+            help='Depth of the parent / children hierarchy nodes. Can be \'full\' or a valid integer',
+            default='full',
+            metavar=''
+    )
+
 def add_argument_id(subparser, help_text='The id of the CQL query'):
     subparser.add_argument(
             '-i',
@@ -322,6 +331,16 @@ def add_argument_includeDrafts(subparser, help_text='Include plugin drafts.'):
             required=False,
             default=True,
             action='store_true'
+    )
+
+def add_argument_includeHierarchyFields(subparser):
+    subparser.add_argument(
+            '-i',
+            '--includeHierarchyFields',
+            help='List of sub fields to include for hierarchies. Only supports \'groups\'',
+            required=False,
+            default=argparse.SUPPRESS,
+            metavar=''
     )
 
 def add_argument_includeIncoming(subparser, help_text='Including incoming dependencies.'):
@@ -1025,22 +1044,9 @@ def subparser_catalog_list(subparser):
             action='store_true',
             required=False
     )
-    sp.add_argument(
-            '-d',
-            '--hierarchy-depth',
-            help='Depth of the parent / children hierarchy nodes. Can be \'full\' or a valid integer',
-            default='full',
-            metavar=''
-    )
+    add_argument_hierarchyDepth(sp)
     add_argument_groups(sp)
-    sp.add_argument(
-            '-i',
-            '--includeHierarchyFields',
-            help='List of sub fields to include for hierarchies. Only supports \'groups\'',
-            default=False,
-            action='store_true',
-            required=False
-    )
+    add_argument_includeHierarchyFields(sp)
     sp.add_argument(
             '-in',
             '--includeNestedFields',
@@ -1123,14 +1129,8 @@ def catalog_descriptor(args):
 
 def subparser_catalog_details(subparser):
     sp = subparser.add_parser('details', help='Retrieve entity details')
-    sp.add_argument(
-            '-i',
-            '--includeHierarchyFields',
-            help='List of sub fields to include for hierarchies. Only supports \'groups\'',
-            default=argparse.SUPPRESS,
-            metavar=''
-    )
-    add_argument_groups(sp)
+    add_argument_includeHierarchyFields(sp)
+    add_argument_hierarchyDepth(sp)
     add_argument_tag(sp)
     sp.set_defaults(func=catalog_details)
 

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -22,6 +22,9 @@ def test_dryrun(capsys):
 def test_details(capsys):
     cli(["catalog", "details", "-t", "cli-test-service"])
 
+def test_details_hierarchy_fields(capsys):
+    cli(["catalog", "details", "-i", "groups", "-t", "cli-test-service"])
+
 def test_list(capsys):
     cli(["catalog", "list"])
 
@@ -30,6 +33,9 @@ def test_list_page(capsys):
 
 def test_list_page_size(capsys):
     cli(["catalog", "list", "-z", "100"])
+
+def test_list_include_hierarchy_fields(capsys):
+    cli(["catalog", "list", "-i", "groups", "-z", "50"])
 
 def test_list_page_and_page_size(capsys):
     cli(["catalog", "list", "-p", "0", "-z", "2"])


### PR DESCRIPTION
This PR:
- fixes the includeHierarchyFields parameter to be a string, changing it from a boolean

This query parameter is currently used in both catalog list and catalog details subcommands.