### PR TITLE
Fix JSON payload formatting for docs update

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.26.3 (2024-05-20)
+------------------
+
+**Bugfixes**
+- fix JSON payload formatting for docs update subcommand
+
 0.26.2 (2024-05-08)
 ------------------
 

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -73,11 +73,12 @@ def read_file(args):
 def read_json_from_yaml(args):
     if str(type(args.file)) == "<class '_io.TextIOWrapper'>":
         data = yaml.safe_load(args.file.read())
+
     else:
         with open(args.file.name, 'rb') as f:
             data = yaml.safe_load(f)
 
-    return '{ "spec": "' + str(data) + '" }'
+    return json.dumps({ "spec": "" + str(data) + "" })
 
 def check_config_file(config_file, replace_string):
     if not os.path.isfile(config_file):

--- a/tests/test_docs.yaml
+++ b/tests/test_docs.yaml
@@ -6,7 +6,7 @@ paths:
   /:
     get:
       operationId: listVersionsv2
-      summary: List API versions
+      summary: List API versions with 'full' history
       responses:
         "200":
           description: 200 response


### PR DESCRIPTION
# This PR
Fixes JSON-formatting of the payload passed to the docs update subcommand.  