### PR TITLE
Ensure scorecards are including in export

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,12 @@
 Release History
 ===============
 
+0.26.5 (2024-06-27)
+------------------
+
+**Bugfixes**
+- Fix bug with scorecards not being included in 'backup export'.
+
 0.26.4 (2024-06-26)
 ------------------
 

--- a/Makefile
+++ b/Makefile
@@ -208,8 +208,10 @@ endif
 
 	@. $(PYTHON_VENV)/bin/activate; PYTHONPATH=cortexapps_cli:tests pytest -rA -n auto -m "not serial" --html=report.html --self-contained-html --cov=cortexapps_cli --cov-append --cov-report term-missing $(PYTEST_PARMS)
 
-test-cli: feature-flags test-api ## Run pytest for CLI-specific tests in the 'tests' directory
-	@. $(PYTHON_VENV)/bin/activate; PYTHONPATH=cortexapps_cli:tests pytest -rA -n 0 -m " serial" --cov=cortexapps_cli --cov-append --cov-report term-missing $(PYTEST_PARMS)
+test-cli: feature-flags test-api cli-tests ## Run pytest for CLI-specific tests in the 'tests' directory
+
+cli-tests: ## Run pytest for CLI-specific tests in the 'tests' directory
+	@. $(PYTHON_VENV)/bin/activate; PYTHONPATH=cortexapps_cli:tests pytest -rA -n 0 -m "serial" --cov=cortexapps_cli --cov-append --cov-report term-missing $(PYTEST_PARMS)
 
 .PHONY: clean
 clean: clean-data

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -809,6 +809,9 @@ def export(args):
                 f1 = open(catalog_directory + "/" + output_tag + ".yaml", 'w')
                 f1.write(str(descriptor) + "\n")
 
+    # Remove page from args so we don't paginate subsequent calls.
+    delattr(args, 'page')
+
     if any(export_type == "ALL" or export_type == "ip-allowlist" for export_type in args.types.split()):
         print("Getting IP Allowlist definitions")
         ip_allowlist_json=json_directory + "/ip-allowlist.json"

--- a/tests/test_config_file.py
+++ b/tests/test_config_file.py
@@ -76,6 +76,12 @@ def test_export(capsys, delete_cortex_api_key):
     sys.stdout.write(last_line + "\n\n")
     assert "rich-sandbox" in out 
 
+    export_directory = last_line.replace("Contents available in ", "")
+    
+    assert len(os.listdir(export_directory + "/catalog")) > 0, "catalog directory has files"
+    assert len(os.listdir(export_directory + "/scorecards")) > 0, "scorecards directory has files"
+    assert len(os.listdir(export_directory + "/resource-definitions")) > 0, "resource-definitions directory has files"
+
 @pytest.mark.serial
 def test_config_file_bad_api_key(tmp_path, capsys, delete_cortex_api_key):
     f = tmp_path / "cortex_config_bad_api_key"


### PR DESCRIPTION
This PR:
fixes a bug with the 'backup export' command.  Scorecards were not included in backups due to recent pagination changes made to speed up the backup process.

Tests have been added to the backup test to ensure that files are produced in the export directories.