### PR TITLE
Ensure gitops tests don't clash across tenants

### DIFF
--- a/.github/workflows/test-api.yml
+++ b/.github/workflows/test-api.yml
@@ -25,6 +25,7 @@ env:
   GH_PAT: ${{ secrets.GH_PAT }}
   GH_WEBHOOK_SECRET: ${{ secrets.GH_WEBHOOK_SECRET_STAGING }}
   CORTEX_GH_WEBHOOK_URL: ${{ vars.CORTEX_GH_WEBHOOK_URL_STAGING }}
+  CORTEX_TENANT: jeff-staging
 
 jobs:
   test:

--- a/Makefile
+++ b/Makefile
@@ -223,6 +223,9 @@ test-cli: feature-flags test-api cli-tests ## Run pytest for CLI-specific tests 
 cli-tests: ## Run pytest for CLI-specific tests in the 'tests' directory
 	@. $(PYTHON_VENV)/bin/activate; PYTHONPATH=cortexapps_cli:tests pytest -rA -n 0 -m "serial" --cov=cortexapps_cli --cov-append --cov-report term-missing $(PYTEST_PARMS)
 
+test-git: feature-flags github ## Run pytest for git tests in the 'tests' directory
+	@. $(PYTHON_VENV)/bin/activate; PYTHONPATH=cortexapps_cli:tests pytest -k test_git
+
 .PHONY: clean
 clean: clean-data
 	@rm -rf $(BUILD_DIR)

--- a/data/run-time/gitops-catalog.tmpl
+++ b/data/run-time/gitops-catalog.tmpl
@@ -5,5 +5,5 @@ info:
     github:
       repository: ${org}/${repo}
       alias: ${alias}
-  x-cortex-tag: gitops2
+  x-cortex-tag: ${environment}-${tenant}-gitops-catalog
   x-cortex-type: service

--- a/tests/cortex_github.py
+++ b/tests/cortex_github.py
@@ -66,7 +66,7 @@ class CortexGithub:
   def read_entity_template(self, file):
       with open (file, 'r') as f:
          template = Template(f.read())
-      return textwrap.dedent(template.substitute(today=today(), org=self.org, repo=self.repo.name, alias=self.alias))
+      return textwrap.dedent(template.substitute(environment=os.getenv('CORTEX_ENV'), tenant=os.getenv('CORTEX_TENANT'), today=today(), org=self.org, repo=self.repo.name, alias=self.alias))
 
 
   # Wait max_attempts * sleep_interval for git commit to appear in gitops-logs

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -5,6 +5,7 @@ from cortex_github import *
 # FAILED tests/test_github_cortex_yaml_in_root.py::test
 # github.GithubException.GithubException: 409 {"message": "is at ef660f9 but expected 418d7ec", "documentation_url":
 @pytest.mark.skipif(enable_ui_editing("SERVICE") == True, reason="Account flag ENABLE_UI_EDITING for SERVICE is true.")
+@pytest.mark.skipif(os.getenv('CORTEX_ENV') != "staging" or os.getenv('CORTEX_TENANT') != "jeff-sandbox", reason="To prevent git commit clashes, the test for cortex.yaml in the root will only run for main API test in staging")
 def test_github_cortex_yaml_in_root(capsys):
     assert gitops_add(capsys, "data/run-time/gitops.tmpl", "cortex.yaml") == True, "failed to find commit in gitops-logs"
 
@@ -13,6 +14,6 @@ def test_github_cortex_yaml_in_root(capsys):
 
 @pytest.mark.skipif(enable_ui_editing("SERVICE") == True, reason="Account flag ENABLE_UI_EDITING for SERVICE is true.")
 def test_github_entity_in_dot_cortex(capsys):
-    assert gitops_add(capsys, "data/run-time/gitops2.tmpl", ".cortex/catalog/gitops2.yaml") == True, "failed to find commit in gitops-logs"
-    response = cli_command(capsys, ["catalog", "details", "-t", "gitops2"])
-    assert response['tag'] == "gitops2"
+    assert gitops_add(capsys, "data/run-time/gitops-catalog.tmpl", ".cortex/catalog/" + os.getenv('CORTEX_ENV') + "-" + os.getenv('CORTEX_TENANT') + "-gitops-catalog.yaml") == True, "failed to find commit in gitops-logs"
+    response = cli_command(capsys, ["catalog", "details", "-t", os.getenv('CORTEX_ENV') + "-" + os.getenv('CORTEX_TENANT') + "-gitops-catalog"])
+    assert response['tag'] == os.getenv('CORTEX_ENV') + "-" + os.getenv('CORTEX_TENANT') + "-gitops-catalog"


### PR DESCRIPTION
**This PR:**
Changes the current gitops tests to ensure that files changed in repo public-api-test-repo are unique across environments.

The test for cortex.yaml in the root of the repository will only run for the main staging test.  All other tests will create a unique file in the repo.  The value of x-cortex-tag will match the file name.

For example, instead of creating an entity named gitops2, the entity will be named <CORTEX_ENV>-<CORTEX_TENANT>-gitops-catalog and the filename will be .cortex/catalog/<CORTEX_ENV>-<CORTEX_TENANT>-gitops-catalog.yaml.

This will provide flexibility for adding new git tests with different directory structures.

In the event that testing is desired for cortex.yaml in the root in other tenants, separate git repositories will need to be created.