### PR TITLE
103 dry run flag not working for catalog create

### DIFF
--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -997,7 +997,7 @@ def subparser_catalog_create_or_update(subparser):
     add_argument_file(sp, 'File containing openapi descriptor for entity')
     sp.add_argument(
             '-d',
-            '--dry-run',
+            '--dryRun',
             help='When true, this endpoint only validates the descriptor contents and returns any errors or warnings.',
             action='store_true',
             default='false'

--- a/cortexapps_cli/cortex.py
+++ b/cortexapps_cli/cortex.py
@@ -997,7 +997,8 @@ def subparser_catalog_create_or_update(subparser):
     add_argument_file(sp, 'File containing openapi descriptor for entity')
     sp.add_argument(
             '-d',
-            '--dryRun',
+            '--dry-run',
+            dest="dryRun",
             help='When true, this endpoint only validates the descriptor contents and returns any errors or warnings.',
             action='store_true',
             default='false'

--- a/data/run-time/create-dryrun.yaml
+++ b/data/run-time/create-dryrun.yaml
@@ -1,0 +1,6 @@
+openapi: 3.0.0
+info:
+  title: Create Entity DryRun
+  description: Entity that should never be created; only used to test catalog dryRun
+  x-cortex-tag: create-entity-dryrun
+  x-cortex-type: service

--- a/tests/test_catalog_dryrun.py
+++ b/tests/test_catalog_dryrun.py
@@ -1,7 +1,7 @@
 from common import *
 
 def test(capsys):
-    cli(["-q", "catalog", "create", "-f", "data/run-time/create-dryrun.yaml", "--dryRun"])
+    cli(["-q", "catalog", "create", "-f", "data/run-time/create-dryrun.yaml", "--dry-run"])
     # Need to clear captured system output from the above commands to clear the way for the next one.
     capsys.readouterr()
 

--- a/tests/test_catalog_dryrun.py
+++ b/tests/test_catalog_dryrun.py
@@ -1,0 +1,14 @@
+from common import *
+
+def test(capsys):
+    cli(["-q", "catalog", "create", "-f", "data/run-time/create-dryrun.yaml", "--dryRun"])
+    # Need to clear captured system output from the above commands to clear the way for the next one.
+    capsys.readouterr()
+
+    # Entity should not exist.
+    with pytest.raises(SystemExit) as excinfo:
+       cli(["catalog", "descriptor", "-t", "create-entity-dryrun"])
+       out, err = capsys.readouterr()
+
+       assert out == "Not Found"
+       assert excinfo.value.code == 404


### PR DESCRIPTION
This PR fixes a bug with the dryRun query parameter used with the catalog create endpoint.  It is being passed as "dry_run=true|false", but it should be "dryRun=true|false".