### PR TITLE
Workaround for homebrew timestamp prior to 1980 zipfile error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -61,6 +61,7 @@ jobs:
       run: |
         poetry config pypi-token.pypi ${{ secrets.PYPI_API_TOKEN }}
         poetry version ${{ env.VERSION }}
+        export SOURCE_DATE_EPOCH=$(date +%s) # https://github.com/cortexapps/cli/issues/121
         poetry build
         poetry publish
         sha=$(sha256sum dist/*.tar.gz | awk '{ print $1 }')


### PR DESCRIPTION
GitHub Actions workaround for homebrew error: ValueError: ZIP does not support timestamps before 1980.  Apparently due to an issue in poetry-core 2.1.3.