### PR TITLE
fix: remove rate limiter initialization log message

### DIFF
--- a/cortexapps_cli/cortex_client.py
+++ b/cortexapps_cli/cortex_client.py
@@ -85,7 +85,6 @@ class CortexClient:
         # Client-side rate limiter (default: 1000 req/min = 16.67 req/sec)
         # Allows bursting up to 50 requests, then enforces rate limit
         self.rate_limiter = TokenBucket(rate=rate_limit/60.0, capacity=50)
-        self.logger.info(f"Rate limiter initialized: {rate_limit} req/min (burst: 50)")
 
         # Create a session with connection pooling for better performance
         self.session = requests.Session()


### PR DESCRIPTION
## Summary
Removes the INFO log message that appears on every CLI invocation:
```
INFO:cortexapps_cli.cortex_client:Rate limiter initialized: 1000 req/min (burst: 50)
```

## Problem
This log message can impact applications that depend on parsing CLI output, as unexpected log lines may break parsing logic.

## Solution
Removed the `self.logger.info()` call in `cortexapps_cli/cortex_client.py` line 88.

## Test plan
- [x] Verified log message no longer appears when running CLI commands
- [x] Rate limiting functionality still works (initialization happens silently)

Fixes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)