### PR TITLE
Fix #171: Initialize results/failed_count before directory check in import functions

### DIFF
--- a/cortexapps_cli/commands/backup.py
+++ b/cortexapps_cli/commands/backup.py
@@ -472,6 +472,8 @@ def _import_entity_relationships(ctx, directory):
     return ("entity-relationships", len(results) - failed_count, [(fp, et, em) for rt, fp, et, em in results if et])
 
 def _import_catalog(ctx, directory):
+    results = []
+    failed_count = 0
     if os.path.isdir(directory):
         print("Processing: " + directory)
         files = [(filename, os.path.join(directory, filename))
@@ -507,6 +509,8 @@ def _import_catalog(ctx, directory):
     return ("catalog", len(results) - failed_count, [(fp, et, em) for fn, fp, et, em in results if et])
 
 def _import_plugins(ctx, directory):
+    results = []
+    failed_count = 0
     if os.path.isdir(directory):
         print("Processing: " + directory)
         files = [(filename, os.path.join(directory, filename))
@@ -543,6 +547,8 @@ def _import_plugins(ctx, directory):
     return ("plugins", len(results) - failed_count, [(fp, et, em) for fn, fp, et, em in results if et])
 
 def _import_scorecards(ctx, directory):
+    results = []
+    failed_count = 0
     if os.path.isdir(directory):
         print("Processing: " + directory)
         files = [(filename, os.path.join(directory, filename))
@@ -579,6 +585,8 @@ def _import_scorecards(ctx, directory):
     return ("scorecards", len(results) - failed_count, [(fp, et, em) for fn, fp, et, em in results if et])
 
 def _import_workflows(ctx, directory):
+    results = []
+    failed_count = 0
     if os.path.isdir(directory):
         print("Processing: " + directory)
         files = [(filename, os.path.join(directory, filename))


### PR DESCRIPTION
Fixes #171

## Problem
When importing a partial export (e.g., only workflows), the import command crashed with:
```
UnboundLocalError: cannot access local variable 'results' where it is not associated with a value
```

## Root Cause
Several `_import_*` functions only initialized `results` and `failed_count` inside the `if os.path.isdir(directory):` block, but referenced them in the return statement outside the block.

## Changes
Fixed 4 functions to initialize variables before the directory check:
- `_import_catalog`: Added `results = []` and `failed_count = 0`
- `_import_plugins`: Added `results = []` and `failed_count = 0`
- `_import_scorecards`: Added `results = []` and `failed_count = 0`
- `_import_workflows`: Added `results = []` and `failed_count = 0`

## Testing
- Created partial export with only workflows: `cortex backup export -e workflows`
- Successfully imported without UnboundLocalError
- Import correctly handles missing directories and returns appropriate statistics