### PR TITLE
Fix #172: Only retry on 429 rate limit errors, not 5xx server errors

### DIFF
--- a/cortexapps_cli/cortex_client.py
+++ b/cortexapps_cli/cortex_client.py
@@ -98,7 +98,7 @@ class CortexClient:
             max_retries=Retry(
                 total=3,
                 backoff_factor=0.3,
-                status_forcelist=[500, 502, 503, 504],  # Removed 429 - we avoid it with rate limiting
+                status_forcelist=[429],  # Only retry on rate limit errors
                 allowed_methods=["GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"],
                 respect_retry_after_header=True
             )


### PR DESCRIPTION
Fixes #172

## Changes
- Changed `status_forcelist` from `[500, 502, 503, 504]` to `[429]`
- Only retries on 429 (Too Many Requests / Rate Limit) responses
- Removes retry logic for 5xx server errors

## Rationale
- Most HTTP errors won't succeed on retry:
  - 4xx client errors: Invalid request, missing auth, not found, etc.
  - 5xx server errors: Typically indicate a real backend issue
- 429 rate limit errors benefit from retry with backoff
- Avoids wasting time on retries that won't succeed
- Client-side rate limiting already prevents most 429 errors

## Impact
- Faster failure on non-transient errors
- Reduced unnecessary load on API servers
- Users get immediate feedback on actual errors