### PR TITLE
Fix #170: Change default logging level from INFO to WARNING

### DIFF
--- a/cortexapps_cli/cli.py
+++ b/cortexapps_cli/cli.py
@@ -87,7 +87,7 @@ def global_callback(
     url: str = typer.Option(None, "--url", "-u", help="Base URL for the API", envvar="CORTEX_BASE_URL"),
     config_file: str = typer.Option(os.path.join(os.path.expanduser('~'), '.cortex', 'config'), "--config", "-c", help="Config file path", envvar="CORTEX_CONFIG"),
     tenant: str = typer.Option("default", "--tenant", "-t", help="Tenant alias", envvar="CORTEX_TENANT_ALIAS"),
-    log_level: Annotated[str, typer.Option("--log-level", "-l", help="Set the logging level")] = "INFO",
+    log_level: Annotated[str, typer.Option("--log-level", "-l", help="Set the logging level")] = "WARNING",
     rate_limit: int = typer.Option(None, "--rate-limit", "-r", help="API rate limit in requests per minute (default: 1000)", envvar="CORTEX_RATE_LIMIT")
 ):
     if not ctx.obj:


### PR DESCRIPTION
Fixes #170

## Changes
- Default logging level changed from INFO to WARNING
- Users no longer see noisy INFO messages in CLI output by default
- CLI output is now cleaner and suitable for parsing by other tools
- Users can still enable full diagnostics with `-l DEBUG` or `-l INFO`
- WARNING level still shows slow request warnings and errors

## File Changes
- `cortexapps_cli/cli.py`: Line 90 - changed default from `INFO` to `WARNING`