### PR TITLE
chore: tests for iconTag parameter in entity-types create

### DIFF
--- a/data/import/entity-types/cli-test.json
+++ b/data/import/entity-types/cli-test.json
@@ -1,5 +1,6 @@
 {
   "description": "This is a test entity type definition.",
+  "iconTag": "Cortex-builtin::Basketball",
   "name": "CLI Test With Empty Schema",
   "schema": {},
   "type": "cli-test"

--- a/data/run-time/entity-type-invalid-icon.json
+++ b/data/run-time/entity-type-invalid-icon.json
@@ -1,0 +1,7 @@
+{
+  "description": "This is a test entity type definition with invalid icon.",
+  "iconTag": "invalidIcon",
+  "name": "CLI Test With Invalid Icon",
+  "schema": {},
+  "type": "cli-test-invalid-icon"
+}

--- a/tests/test_entity_types.py
+++ b/tests/test_entity_types.py
@@ -12,6 +12,18 @@ def test_resource_definitions(capsys):
     response = cli(["entity-types", "list"])
     assert any(definition['type'] == 'cli-test' for definition in response['definitions']), "Should find entity type named 'cli-test'"
 
-    cli(["entity-types", "get", "-t", "cli-test"])
+    # Verify iconTag was set correctly
+    response = cli(["entity-types", "get", "-t", "cli-test"])
+    assert response.get('iconTag') == "Cortex-builtin::Basketball", "iconTag should be set to Cortex-builtin::Basketball"
 
     cli(["entity-types", "update", "-t", "cli-test", "-f", "data/run-time/entity-type-update.json"])
+
+
+def test_resource_definitions_invalid_icon():
+    # API does not reject invalid iconTag values - it uses a default icon instead
+    # This test verifies that behavior and will catch if the API changes to reject invalid icons
+    response = cli(["entity-types", "create", "-f", "data/run-time/entity-type-invalid-icon.json"], return_type=ReturnType.RAW)
+    assert response.exit_code == 0, "Creation should succeed even with invalid iconTag (API uses default icon)"
+
+    # Clean up the test entity type
+    cli(["entity-types", "delete", "-t", "cli-test-invalid-icon"])


### PR DESCRIPTION
- Add iconTag to cli-test.json with valid value (Cortex-builtin::Basketball)
- Add test to verify iconTag is returned correctly after create
- Add test for invalid iconTag (API accepts and uses default icon)
- Add test data file for invalid icon scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)