### PR TITLE
fix: convert deploy timestamps to UTC before sending

### DIFF
--- a/cortexapps_cli/commands/deploys.py
+++ b/cortexapps_cli/commands/deploys.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 import json
 from rich import print_json
@@ -168,7 +168,7 @@ def add(
 
         if customData:
             data["customData"] = dict(customData)
-        data["timestamp"] = data["timestamp"].strftime('%Y-%m-%dT%H:%M:%SZ')
+        data["timestamp"] = data["timestamp"].astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     r = client.post("api/v1/catalog/" + tag + "/deploys", data=data)
     print_json(data=r)
@@ -236,7 +236,7 @@ def update_by_uuid(
                 data["deployer"]["email"] = email
             if name:
                 data["deployer"]["name"] = name
-        data["timestamp"] = data["timestamp"].strftime('%Y-%m-%dT%H:%M:%SZ')
+        data["timestamp"] = data["timestamp"].astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
 
     r = client.put("api/v1/catalog/" + tag + "/deploys/" + uuid, data=data)
     print_json(data=r)

--- a/tests/test_deploys_timestamp.py
+++ b/tests/test_deploys_timestamp.py
@@ -1,0 +1,47 @@
+import time
+
+from tests.helpers.utils import *
+
+# Fixed-offset zone (UTC-5, no DST) so the local->UTC conversion is deterministic
+# regardless of the machine/CI timezone.
+_TZ = "Etc/GMT+5"
+
+
+def _with_fixed_tz(fn):
+    old_tz = os.environ.get("TZ")
+    os.environ["TZ"] = _TZ
+    time.tzset()
+    try:
+        fn()
+    finally:
+        if old_tz is None:
+            os.environ.pop("TZ", None)
+        else:
+            os.environ["TZ"] = old_tz
+        time.tzset()
+
+
+def _posted_timestamp(cli_args):
+    responses.add(
+        responses.POST,
+        os.getenv("CORTEX_BASE_URL") + "/api/v1/catalog/cli-test-service/deploys",
+        json={},
+        status=200,
+    )
+    cli(cli_args)
+    return json.loads(responses.calls[0].request.body)["timestamp"]
+
+
+@responses.activate
+def test_add_converts_local_timestamp_to_utc():
+    """An explicit local --timestamp is converted to UTC before being sent with a Z suffix"""
+    def check():
+        ts = _posted_timestamp([
+            "deploys", "add", "-t", "cli-test-service",
+            "--title", "my title", "--type", "DEPLOY",
+            "--timestamp", "2020-01-15T10:30:00",
+        ])
+        # 10:30 in UTC-5 is 15:30 UTC
+        assert ts == "2020-01-15T15:30:00Z"
+
+    _with_fixed_tz(check)


### PR DESCRIPTION
## Problem

`cortex deploys add` (with no `--timestamp`) returns a timestamp that displays with the wrong time in the Cortex UI. Example — run at 11:26 PDT:

```json
{ "timestamp": "2026-07-13T11:26:52Z", ... }
```

`11:26` was the **local** wall-clock time, but it's labeled `Z` (UTC). The true UTC was `18:26`. So every deploy is off by the client's UTC offset.

## Root cause

In `cortexapps_cli/commands/deploys.py`:

- The default is naive **local** time: `timestamp: datetime = typer.Option(datetime.now(), ...)`
- It's then formatted with a **hardcoded `Z`**: `data["timestamp"].strftime('%Y-%m-%dT%H:%M:%SZ')`

So local time goes on the wire mislabeled as UTC. The backend (brain-backend) trusts the offset and round-trips the instant faithfully — the bug is entirely client-side.

## Fix

Interpret the naive timestamp as local time and convert to UTC before formatting, so the `Z` is truthful. `.astimezone(timezone.utc)` treats a naive datetime as the machine's local time. Applied to both `add` and `update-by-uuid`; covers the `datetime.now()` default and an explicit `--timestamp`.

```python
data["timestamp"] = data["timestamp"].astimezone(timezone.utc).strftime('%Y-%m-%dT%H:%M:%SZ')
```

**Behavior note:** an explicit `--timestamp 2026-07-13T10:00:00` (which carries no offset) is now interpreted as **local** and converted to UTC, rather than being sent as-is-with-`Z`. This is consistent with the `datetime.now()` default and matches what a human means when typing a wall-clock time.

## Tests

Added `tests/test_deploys_timestamp.py` — mocks the POST (via `responses`), pins a fixed offset zone, and asserts the outgoing payload's timestamp is converted to UTC (`10:30` local UTC-5 → `15:30:00Z`). Pre-fix code emitted `10:30:00Z`, so this is a regression guard.

## Out of scope (flagging for follow-up)

`update-by-uuid`'s flag-based path has a **separate, pre-existing bug**: its guard `if not title or tag or deploy_type:` is always truthy (since `tag` is required), so it raises before sending whenever `-f` isn't used. The timestamp fix on that line is correct but currently only reachable once that guard is fixed. Not addressed here to keep this PR focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)