### PR TITLE
chore: suppress automerge failure when PR is in unstable state

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -83,4 +83,4 @@ jobs:
     - name: Auto-merge PR
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: gh pr merge ${{ github.event.pull_request.number }} --merge --auto --repo ${{ github.repository }}
+      run: gh pr merge ${{ github.event.pull_request.number }} --merge --auto --repo ${{ github.repository }} || true


### PR DESCRIPTION
## Summary

- Adds `|| true` to the automerge step so it doesn't fail the job when GitHub rejects `--auto` due to the PR being in an unstable state (race condition where status checks are still settling after the test job completes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)