### PR TITLE
Fix Prometheus integration payload and validation endpoints

### DIFF
--- a/cortexapps_cli/commands/integrations_commands/prometheus.py
+++ b/cortexapps_cli/commands/integrations_commands/prometheus.py
@@ -33,8 +33,8 @@ def add(
            "host": host,
            "username": username,
            "password": password,
-           "tenant_id": tenant_id,
-           "is_default": is_default
+           "tenantId": tenant_id,
+           "isDefault": is_default
         }       
 
         for k, v in data.items():
@@ -159,7 +159,7 @@ def validate(
 
     client = ctx.obj["client"]
 
-    r = client.post("api/v1/prometheus/configurations/validate" + alias)
+    r = client.post("api/v1/prometheus/configuration/validate/" + alias)
     print_json(data=r)
 
 @app.command()
@@ -172,5 +172,5 @@ def validate_all(
 
     client = ctx.obj["client"]
 
-    r = client.post("api/v1/prometheus/configurations")
+    r = client.post("api/v1/prometheus/configuration/validate")
     print_json(data=r)

--- a/tests/test_integrations_prometheus.py
+++ b/tests/test_integrations_prometheus.py
@@ -1,4 +1,5 @@
 from tests.helpers.utils import *
+import json
 
 # Since responses are all mocked and no data validation is done by the CLI --
 # we let the API handle validation -- we don't need valid input files.
@@ -11,6 +12,12 @@ def _dummy_file(tmp_path):
 def test_integrations_prometheus_add():
     responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/prometheus/configuration", json={}, status=200)
     cli(["integrations", "prometheus", "add", "-a", "myAlias", "-h", "my.host.com", "--username", "my-user", "--password", "my-password", "-t", "my-tenant", "-i"])
+    body = json.loads(responses.calls[0].request.body)
+    assert body["password"] == "my-password"
+    assert body["tenantId"] == "my-tenant"
+    assert body["isDefault"] is True
+    assert "tenant_id" not in body
+    assert "is_default" not in body
 
 @responses.activate
 def test_integrations_prometheus_add_multiple(tmp_path):


### PR DESCRIPTION
## Summary
- send Prometheus tenant/default fields with the same camelCase shape used by the API and update command
- keep password in the generated add payload and add regression assertions for the request body
- correct Prometheus validate endpoints to the singular configuration validate routes covered by tests

Fixes #136.

## Testing
- CORTEX_BASE_URL=http://localhost CORTEX_API_KEY=test POETRY_CACHE_DIR=/private/tmp/cortexapps-cli-poetry-cache poetry run pytest tests/test_integrations_prometheus.py -k "not add_multiple" -q