### PR TITLE
Use POST for integration add-multiple commands

### DIFF
--- a/cortexapps_cli/commands/integrations_commands/apiiro.py
+++ b/cortexapps_cli/commands/integrations_commands/apiiro.py
@@ -49,7 +49,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/apiiro/configurations", data=data)
+    r = client.post("api/v1/apiiro/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/argocd.py
+++ b/cortexapps_cli/commands/integrations_commands/argocd.py
@@ -53,7 +53,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/argocd/configurations", data=data)
+    r = client.post("api/v1/argocd/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/azure_devops.py
+++ b/cortexapps_cli/commands/integrations_commands/azure_devops.py
@@ -55,7 +55,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/azure-devops/configurations", data=data)
+    r = client.post("api/v1/azure-devops/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/azure_resources.py
+++ b/cortexapps_cli/commands/integrations_commands/azure_resources.py
@@ -81,7 +81,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/azure-resources/configurations", data=data)
+    r = client.post("api/v1/azure-resources/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/bitbucket.py
+++ b/cortexapps_cli/commands/integrations_commands/bitbucket.py
@@ -34,7 +34,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/bitbucket/configurations", data=data)
+    r = client.post("api/v1/bitbucket/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/circleci.py
+++ b/cortexapps_cli/commands/integrations_commands/circleci.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/circleci/configurations", data=data)
+    r = client.post("api/v1/circleci/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/coralogix.py
+++ b/cortexapps_cli/commands/integrations_commands/coralogix.py
@@ -60,7 +60,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/coralogix/configurations", data=data)
+    r = client.post("api/v1/coralogix/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/datadog.py
+++ b/cortexapps_cli/commands/integrations_commands/datadog.py
@@ -59,7 +59,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/datadog/configurations", data=data)
+    r = client.post("api/v1/datadog/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/gitlab.py
+++ b/cortexapps_cli/commands/integrations_commands/gitlab.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/gitlab/configurations", data=data)
+    r = client.post("api/v1/gitlab/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/incidentio.py
+++ b/cortexapps_cli/commands/integrations_commands/incidentio.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/incidentio/configurations", data=data)
+    r = client.post("api/v1/incidentio/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/jenkins.py
+++ b/cortexapps_cli/commands/integrations_commands/jenkins.py
@@ -53,7 +53,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/jenkins/configurations", data=data)
+    r = client.post("api/v1/jenkins/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/jira.py
+++ b/cortexapps_cli/commands/integrations_commands/jira.py
@@ -34,7 +34,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/jira/configurations", data=data)
+    r = client.post("api/v1/jira/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/launchdarkly.py
+++ b/cortexapps_cli/commands/integrations_commands/launchdarkly.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/launchdarkly/configurations", data=data)
+    r = client.post("api/v1/launchdarkly/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/pagerduty.py
+++ b/cortexapps_cli/commands/integrations_commands/pagerduty.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/pagerduty/configurations", data=data)
+    r = client.post("api/v1/pagerduty/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/prometheus.py
+++ b/cortexapps_cli/commands/integrations_commands/prometheus.py
@@ -57,7 +57,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/prometheus/configurations", data=data)
+    r = client.post("api/v1/prometheus/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/rootly.py
+++ b/cortexapps_cli/commands/integrations_commands/rootly.py
@@ -49,7 +49,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/rootly/configurations", data=data)
+    r = client.post("api/v1/rootly/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/semgrep.py
+++ b/cortexapps_cli/commands/integrations_commands/semgrep.py
@@ -53,7 +53,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/semgrep/configurations", data=data)
+    r = client.post("api/v1/semgrep/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/cortexapps_cli/commands/integrations_commands/sonarqube.py
+++ b/cortexapps_cli/commands/integrations_commands/sonarqube.py
@@ -51,7 +51,7 @@ def add_multiple(
 
     data = json.loads("".join([line for line in file_input]))
 
-    r = client.put("api/v1/sonarqube/configurations", data=data)
+    r = client.post("api/v1/sonarqube/configurations", data=data)
     print_json(data=r)
 
 @app.command()

--- a/tests/test_integrations_apiiro.py
+++ b/tests/test_integrations_apiiro.py
@@ -68,5 +68,5 @@ def test_integrations_apiiro_add_file_with_flags_error(tmp_path):
 def test_integrations_apiiro_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/apiiro/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/apiiro/configurations", json={}, status=200)
     cli(["integrations", "apiiro", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_argocd.py
+++ b/tests/test_integrations_argocd.py
@@ -68,5 +68,5 @@ def test_integrations_argocd_add_file_with_flags_error(tmp_path):
 def test_integrations_argocd_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/argocd/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/argocd/configurations", json={}, status=200)
     cli(["integrations", "argocd", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_azure_devops.py
+++ b/tests/test_integrations_azure_devops.py
@@ -68,5 +68,5 @@ def test_integrations_azure_devops_add_file_with_flags_error(tmp_path):
 def test_integrations_azure_devops_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/azure-devops/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/azure-devops/configurations", json={}, status=200)
     cli(["integrations", "azure-devops", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_bitbucket.py
+++ b/tests/test_integrations_bitbucket.py
@@ -70,5 +70,5 @@ def test_integrations_bitbucket_add_valid(tmp_path):
 def test_integrations_bitbucket_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/bitbucket/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/bitbucket/configurations", json={}, status=200)
     cli(["integrations", "bitbucket", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_circleci.py
+++ b/tests/test_integrations_circleci.py
@@ -68,5 +68,5 @@ def test_integrations_circleci_add_file_with_flags_error(tmp_path):
 def test_integrations_circleci_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/circleci/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/circleci/configurations", json={}, status=200)
     cli(["integrations", "circleci", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_coralogix.py
+++ b/tests/test_integrations_coralogix.py
@@ -68,5 +68,5 @@ def test_integrations_coralogix_add_file_with_flags_error(tmp_path):
 def test_integrations_coralogix_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/coralogix/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/coralogix/configurations", json={}, status=200)
     cli(["integrations", "coralogix", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_datadog.py
+++ b/tests/test_integrations_datadog.py
@@ -68,5 +68,5 @@ def test_integrations_datadog_add_file_with_flags_error(tmp_path):
 def test_integrations_datadog_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/datadog/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/datadog/configurations", json={}, status=200)
     cli(["integrations", "datadog", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_gitlab.py
+++ b/tests/test_integrations_gitlab.py
@@ -68,5 +68,5 @@ def test_integrations_gitlab_add_file_with_flags_error(tmp_path):
 def test_integrations_gitlab_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/gitlab/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/gitlab/configurations", json={}, status=200)
     cli(["integrations", "gitlab", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_incidentio.py
+++ b/tests/test_integrations_incidentio.py
@@ -68,5 +68,5 @@ def test_integrations_incidentio_add_file_with_flags_error(tmp_path):
 def test_integrations_incidentio_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/incidentio/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/incidentio/configurations", json={}, status=200)
     cli(["integrations", "incidentio", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_jenkins.py
+++ b/tests/test_integrations_jenkins.py
@@ -68,5 +68,5 @@ def test_integrations_jenkins_add_file_with_flags_error(tmp_path):
 def test_integrations_jenkins_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/jenkins/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/jenkins/configurations", json={}, status=200)
     cli(["integrations", "jenkins", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_jira.py
+++ b/tests/test_integrations_jira.py
@@ -70,5 +70,5 @@ def test_integrations_jira_add_valid(tmp_path):
 def test_integrations_jira_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/jira/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/jira/configurations", json={}, status=200)
     cli(["integrations", "jira", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_launchdarkly.py
+++ b/tests/test_integrations_launchdarkly.py
@@ -68,5 +68,5 @@ def test_integrations_launchdarkly_add_file_with_flags_error(tmp_path):
 def test_integrations_launchdarkly_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/launchdarkly/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/launchdarkly/configurations", json={}, status=200)
     cli(["integrations", "launchdarkly", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_pagerduty.py
+++ b/tests/test_integrations_pagerduty.py
@@ -68,5 +68,5 @@ def test_integrations_pagerduty_add_file_with_flags_error(tmp_path):
 def test_integrations_pagerduty_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/pagerduty/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/pagerduty/configurations", json={}, status=200)
     cli(["integrations", "pagerduty", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_prometheus.py
+++ b/tests/test_integrations_prometheus.py
@@ -68,5 +68,5 @@ def test_integrations_prometheus_add_file_with_flags_error(tmp_path):
 def test_integrations_prometheus_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/prometheus/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/prometheus/configurations", json={}, status=200)
     cli(["integrations", "prometheus", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_rootly.py
+++ b/tests/test_integrations_rootly.py
@@ -68,5 +68,5 @@ def test_integrations_rootly_add_file_with_flags_error(tmp_path):
 def test_integrations_rootly_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/rootly/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/rootly/configurations", json={}, status=200)
     cli(["integrations", "rootly", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_semgrep.py
+++ b/tests/test_integrations_semgrep.py
@@ -68,5 +68,5 @@ def test_integrations_semgrep_add_file_with_flags_error(tmp_path):
 def test_integrations_semgrep_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/semgrep/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/semgrep/configurations", json={}, status=200)
     cli(["integrations", "semgrep", "add-multiple", "-f", str(f)])

--- a/tests/test_integrations_sonarqube.py
+++ b/tests/test_integrations_sonarqube.py
@@ -90,5 +90,5 @@ def test_integrations_sonarqube_add_file_with_flags_error(tmp_path):
 def test_integrations_sonarqube_add_multiple_valid(tmp_path):
     f = tmp_path / "valid.json"
     f.write_text('{"configurations": []}')
-    responses.add(responses.PUT, os.getenv("CORTEX_BASE_URL") + "/api/v1/sonarqube/configurations", json={}, status=200)
+    responses.add(responses.POST, os.getenv("CORTEX_BASE_URL") + "/api/v1/sonarqube/configurations", json={}, status=200)
     cli(["integrations", "sonarqube", "add-multiple", "-f", str(f)])


### PR DESCRIPTION
## Summary
- switch generated add-multiple integration commands from PUT to POST for configuration creation endpoints
- keep AWS unchanged because its command already has separate add/update semantics
- align add-multiple valid-input tests with the POST behavior already expected by the basic add-multiple tests

Fixes #140.

## Testing
- CORTEX_BASE_URL=http://localhost CORTEX_API_KEY=test POETRY_CACHE_DIR=/private/tmp/cortexapps-cli-poetry-cache poetry run pytest tests/test_integrations_*.py -k add_multiple -q