### PR TITLE
fix: upgrade setuptools and msgpack in Docker image to fix Trivy HIGH…

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-slim
 
-RUN pip install --upgrade pip
+RUN pip install --upgrade pip "setuptools>=78.1.1" "msgpack>=1.2.1"
 RUN apt update && apt upgrade -y && apt install -y jq yq
 RUN useradd -m cortex
 ADD config /home/cortex/.cortex/config 


### PR DESCRIPTION
… vulnerabilities

- setuptools 70.3.0 → >=78.1.1 (CVE-2025-47273: Path Traversal in PackageIndex)
- msgpack 1.1.2 → >=1.2.1 (GHSA-6v7p-g79w-8964: Out-of-bounds read on Unpacker reuse)