### PR TITLE
harness-deploy: remove empty notes param from pipeline execute URL

### DIFF
--- a/cortexapps_cli/solutions/harness-deploy/_templates/trigger-harness-deploy.yaml
+++ b/cortexapps_cli/solutions/harness-deploy/_templates/trigger-harness-deploy.yaml
@@ -166,7 +166,7 @@ actions:
   schema:
     type: HTTP_REQUEST_ASYNC
     httpMethod: POST
-    url: "/v1/orgs/{{variables.harness-org}}/projects/{{variables.harness-project}}/pipelines/{{variables.harness-pipeline}}/execute?notes=Submitted+by+{{context.initiatedBy.email}}"
+    url: "/v1/orgs/{{variables.harness-org}}/projects/{{variables.harness-project}}/pipelines/{{variables.harness-pipeline}}/execute"
     integration: Harness
     integrationAlias: "PLACEHOLDER_INTEGRATION_ALIAS"
     headers:


### PR DESCRIPTION
## Summary

`context.initiatedBy.email` resolves to an empty string, causing Harness execution notes to show `Submitted by ` with nothing after it. Removing the `?notes=` param until the correct context variable path is known.

## Test plan
- [ ] Harness pipeline execute URL no longer has a trailing empty notes param

🤖 Generated with [Claude Code](https://claude.com/claude-code)